### PR TITLE
Add new option for "enable quick reply"

### DIFF
--- a/content/options.xul
+++ b/content/options.xul
@@ -38,15 +38,15 @@
    - ***** END LICENSE BLOCK ***** -->
 
 <!DOCTYPE window SYSTEM "chrome://conversations/locale/options.dtd">
- 
+
 <vbox xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">
 
-  <setting pref="conversations.expand_who" type="radio" title="&option.expand_who;">  
-    <radiogroup>  
+  <setting pref="conversations.expand_who" type="radio" title="&option.expand_who;">
+    <radiogroup>
       <radio value="1" label="&option.expand_none;" />
       <radio value="3" label="&option.expand_all;" />
       <radio value="4" label="&option.expand_auto2;" tooltiptext="&option.expand_auto2.tooltip;"/>
-    </radiogroup>  
+    </radiogroup>
   </setting>
 
   <setting title="&title.quoting2;" desc="&desc.quoting;" pref="conversations.hide_quote_length" type="integer" />
@@ -69,13 +69,14 @@
     pref="mailnews.sendInBackground" type="bool" />
 
   <setting title="&title.operate_on_conversations;" desc="&option.operate_on_conversations;" pref="conversations.operate_on_conversations" type="bool" />
-  <setting title="&title.assistant;" type="control">  
+  <setting title="&title.assistant;" type="control">
     <button label="&option.assistant;"
       oncommand="window.openDialog('chrome://conversations/content/assistant/assistant.xhtml', '', 'chrome,width=800,height=500');"
      />
   </setting>
   <setting title="&title.extra_attachments;" desc="&desc.extra_attachments2;" pref="conversations.extra_attachments" type="bool" />
   <setting title="&title.compose_in_tab;" desc="&desc.compose_in_tab;" pref="conversations.compose_in_tab" type="bool" />
+  <setting title="&title.enable_quick_reply;" desc="&desc.enable_quick_reply;" pref="conversations.enable_quick_reply" type="bool" />
   <setting title="&title.debugging;" desc="&desc.debugging;" pref="conversations.logging_enabled" type="bool" />
- 
+
 </vbox>

--- a/content/stub.xhtml
+++ b/content/stub.xhtml
@@ -771,7 +771,8 @@
               message._topInView = true;
           }
           if (!message._bottomInView) {
-            let footerClass = (i == messages.length - 1) ? ".quickReply" : ".messageFooter";
+            let footerClass = (Prefs.enable_quick_reply && i == messages.length - 1) ? ".quickReply" : ".messageFooter";
+
             let bottom = $(message._domNode.querySelector(footerClass)).offset().top;
             if (bottom > pageTop && bottom < pageBottom)
               message._bottomInView = true;
@@ -1117,7 +1118,7 @@
         <div class="embedsContainer">
         </div>
       </div>
-      <div class="messageFooter">
+      <div class="messageFooter{{#if quickReply}} quickReplyEnabled{{/if}}">
         <div class="footerActions">
           <button class="edit-draft"><span>{{str "editDraft2"}}</span><span class="ext"></span></button>
           <button class="buttonReply"><span>{{str "reply"}}</span><span class="ext"></span></button>

--- a/defaults/preferences/defaults.js
+++ b/defaults/preferences/defaults.js
@@ -14,3 +14,4 @@ pref("conversations.extra_attachments", false);
 pref("conversations.compose_in_tab", true);
 pref("conversations.unwanted_recipients", "{}");
 pref("conversations.hide_sigs", false);
+pref("conversations.enable_quick_reply", true);

--- a/locale/en-US/options.dtd
+++ b/locale/en-US/options.dtd
@@ -23,6 +23,8 @@
 <!ENTITY option.tweak_chrome "Scale down the font size for the conversation chrome (recommended, requires restart).">
 <!ENTITY title.add_embeds "Add embeds">
 <!ENTITY option.add_embeds "Detect links to various services (e.g. YouTube) in emails, and view them inline.">
+<!ENTITY title.enable_quick_reply "Enable Quick Reply">
+<!ENTITY desc.enable_quick_reply "Enable the Quick Reply dialog at the bottom of a conversation.">
 <!ENTITY title.debugging "Debugging">
 <!ENTITY desc.debugging "Enable debug output in the system console and the error console. This will generate a lot of messages.">
 <!ENTITY title.operate_on_conversations "Toolbar buttons">

--- a/modules/conversation.js
+++ b/modules/conversation.js
@@ -991,7 +991,7 @@ Conversation.prototype = {
       let oldMsg = i > 0 ? this.messages[i-1].message : null;
       msg.updateTmplData(oldMsg);
     }
-    let tmplData = [m.message.toTmplData(i == this.messages.length - 1)
+    let tmplData = [m.message.toTmplData(Prefs.enable_quick_reply && (i == this.messages.length - 1))
       for each ([i, m] in Iterator(this.messages))];
     // We must do this if we are to ever release the previous Conversation
     //  object. See comments in stub.html for the nice details.

--- a/modules/prefs.js
+++ b/modules/prefs.js
@@ -65,6 +65,7 @@ function PrefManager() {
   this.hide_quote_length = prefsService.getIntPref("hide_quote_length");
   this.hide_sigs = prefsService.getBoolPref("hide_sigs");
   this.compose_in_tab = prefsService.getBoolPref("compose_in_tab");
+  this.enable_quick_reply = prefsService.getBoolPref("enable_quick_reply");
   // This is a hashmap
   this.monospaced_senders = {};
   for each (s in this.split(prefsService.getCharPref("monospaced_senders")))
@@ -109,7 +110,8 @@ PrefManager.prototype = {
       case "extra_attachments":
       case "compose_in_tab":
       case "enabled":
-      case "hide_sigs": {
+      case "hide_sigs":
+      case "enable_quick_reply": {
         let v = prefsService.getBoolPref(aData)
         this[aData] = v;
         [x(aData, v) for each (x in this.watchers)];

--- a/skin/quickreply.css
+++ b/skin/quickreply.css
@@ -1,8 +1,9 @@
 /* Hide other actions for the last message */
 
-.message:last-child .messageFooter {
+.message:last-child .messageFooter.quickReplyEnabled {
   display: none;
 }
+
 
 /* Quick reply */
 


### PR DESCRIPTION
While I appreciate greatly the effort and complexity that I can see went into the "Quick Reply" feature at the bottom of the conversation window,  I'd like to support the case for making this feature optional.  In my case, I prefer having a consistent set of controls for writing replies, in particular that I typically need to write my responses inline, I deal with a lot of code samples and complex reply chains,  and in general I need a lot of window room and very consistent controls.  By disabling "Quick Reply" I get the same "Reply" buttons at the bottom of the last message as that of other messages in the thread without the extra boxes and controls getting in the way.

