### PR TITLE
Fix attachments showing with PGP/MIME messages

### DIFF
--- a/modules/message.js
+++ b/modules/message.js
@@ -1166,11 +1166,11 @@ Message.prototype = {
           let tmplData = self.toTmplDataForAttachments();
           let w = self._conversation._htmlPane;
           let $ = w.$;
-          this._conversation.tmpl("#attachmentIconTemplate", tmplData).appendTo(
+          self._conversation.tmpl("#attachmentIconTemplate", tmplData).appendTo(
             $(self._domNode.querySelector(".attachmentIcon")).empty());
-          this._conversation.tmpl("#attachmentDetailsTemplate", tmplData).appendTo(
+          self._conversation.tmpl("#attachmentDetailsTemplate", tmplData).appendTo(
             $(self._domNode.querySelector(".detailsLine")).empty());
-          this._conversation.tmpl("#attachmentsTemplate", tmplData).appendTo(
+          self._conversation.tmpl("#attachmentsTemplate", tmplData).appendTo(
             $(self._domNode.querySelector(".attachments-container")).empty());
 
           try {


### PR DESCRIPTION
I see the same issue with #980.

`this` causes an error. Instead we use `self`.
Fixes #980